### PR TITLE
Fix Check Cache - need the same paths as used in build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -71,7 +71,10 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           lookup-only: true
-          path: content/en/history/bibliography
+          path: |
+            static/data/bibliography.json
+            static/data/bibItems
+            content/en/history/bibliography
           key: bib-${{ fromJson(steps.zoteroVersion.outputs.headers).last-modified-version }}
 
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
Cache hit is based on a hash and part of that includes the directory information.