### PR TITLE
Cleanup.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -139,7 +139,7 @@ jobs:
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
           TZ: America/New York
-        run: hugo --cleanDestinationDir -e $HUGO_ENVIRONMENT --ignoreCache
+        run: hugo --cleanDestinationDir -e $HUGO_ENVIRONMENT 
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/layouts/partials/taxonomy_terms_cloud.html
+++ b/layouts/partials/taxonomy_terms_cloud.html
@@ -2,7 +2,7 @@
 {{ $taxo := .taxo -}}
 {{ $title := .title -}}
 
-{{ if eq $context.Type "bibliography" }}
+{{ if or (eq .Type "bibliography") (in (slice "taxonomy" "term") .Kind) }}
   {{ if isset $context.Site.Taxonomies (lower $taxo) -}}
     {{ $taxonomy := index $context.Site.Taxonomies (lower $taxo) -}}
     {{ if (gt (len $taxonomy) 0) -}}

--- a/scripts/bib-fns.jq
+++ b/scripts/bib-fns.jq
@@ -30,33 +30,6 @@ def issued_iso_string:
     . 
   end;
 
-# Build ["Family, Given", "Family2, Given2", ...] string array from .author array.
-# Falls back to other common shapes (name / firstName+lastName). Skips empty parts.
-def author_string_list:
-  ( .author // [] )
-  | dbg("author_string_list.count"; length)
-  | map(
-      if (has("family") and .family != null and (.family|tostring|length)>0) then
-        .family
-        + ( if (has("given") and .given != null and (.given|tostring|length)>0)
-            then ", " + (.given|tostring)
-            else "" end )
-      elif (has("lastName") and .lastName != null) then
-        .lastName
-        + ( if (has("firstName") and .firstName != null and (.firstName|tostring|length)>0)
-            then ", " + (.firstName|tostring)
-            else "" end )
-      elif (has("name") and .name != null) then
-        .name
-      else
-        empty
-      end
-    );
-
-# If you want the field added into each item:
-def add_author_string:
-  . + { authorsFormattedList: (author_string_list) };
-
 def make_DOI_to_url($doi):
   if ($doi | startswith("https:")) then $doi else "https://doi.org/" + ($doi | ltrimstr("/")) end ;
 

--- a/scripts/bib-fns.jq
+++ b/scripts/bib-fns.jq
@@ -30,33 +30,6 @@ def issued_iso_string:
     .
   end;
 
-# Build ["Family, Given", "Family2, Given2", ...] string array from .author array.
-# Falls back to other common shapes (name / firstName+lastName). Skips empty parts.
-def author_string_list:
-  ( .author // [] )
-  | dbg("author_string_list.count"; length)
-  | map(
-      if (has("family") and .family != null and (.family|tostring|length)>0) then
-        .family
-        + ( if (has("given") and .given != null and (.given|tostring|length)>0)
-            then ", " + (.given|tostring)
-            else "" end )
-      elif (has("lastName") and .lastName != null) then
-        .lastName
-        + ( if (has("firstName") and .firstName != null and (.firstName|tostring|length)>0)
-            then ", " + (.firstName|tostring)
-            else "" end )
-      elif (has("name") and .name != null) then
-        .name
-      else
-        empty
-      end
-    );
-
-# If you want the field added into each item:
-def add_author_string:
-  . + { authorsFormattedList: (author_string_list) };
-
 def raise_issued_date_parts:
   if nonBlankKey("issued") and (.issued | nonBlankKey("date-parts")) then setpath(["issuedDateParts"]; .issued."date-parts"[0]) else . end;
 
@@ -69,33 +42,6 @@ def issued_iso_string:
   else
     .
   end;
-
-# Build "Family, Given; Family2, Given2" string from .author array.
-# Falls back to other common shapes (name / firstName+lastName). Skips empty parts.
-def author_string:
-  ( .author // [] )                                     # if no authors → empty array
-  | map(
-      if (has("family") and .family != null and (.family|tostring|length)>0) then
-        .family
-        + ( if (has("given") and .given != null and (.given|tostring|length)>0)
-            then ", " + (.given|tostring)
-            else "" end )
-      elif (has("lastName") and .lastName != null) then
-        .lastName
-        + ( if (has("firstName") and .firstName != null and (.firstName|tostring|length)>0)
-            then ", " + (.firstName|tostring)
-            else "" end )
-      elif (has("name") and .name != null) then
-        .name
-      else
-        empty
-      end
-    )
-  | join("; ");
-
-# If you want the field added into each item:
-def add_author_string:
-  . + { authorsFormatted: (author_string) };
 
 def make_DOI_to_url($doi):
   if ($doi | startswith("https:")) then $doi else "https://doi.org/" + ($doi | ltrimstr("/")) end ;

--- a/scripts/bibSplit.pl
+++ b/scripts/bibSplit.pl
@@ -119,9 +119,9 @@ if ($key eq $target) {  # only top level entries
 
   add_editor_string($obj);
   my $itemEditors = '';
-  if (ref($obj->{editorsFormatted}) eq 'ARRAY' && @{$obj->{editorsFormatted}}) {
+  if (ref($obj->{editorsFormattedList}) eq 'ARRAY' && @{$obj->{editorsFormattedList}}) {
     $itemEditors = "\n";
-    for my $a (@{$obj->{editorsFormatted}}) {
+    for my $a (@{$obj->{editorsFormattedList}}) {
       my $quoted = encode_json($a // '');
       $itemEditors .= "  - $quoted\n";
     }

--- a/scripts/update_bibliography.sh
+++ b/scripts/update_bibliography.sh
@@ -267,9 +267,6 @@ finalCount=$(jq '. | length' <<< "$items")
 
 items=$(jq 'include "./bib-fns";map(issued_iso_string)' <<< "$items")
 
-#items=$(jq 'include "./bib-fns";map(add_author_string)' <<< "$items")
-
-#items=$(jq 'include "./bib-fns";map(add_editor_string)' <<< "$items")
 # if $removeChildrenFromFinalFile; then
 #   # Remove .children arrays, if any. Save space.
 #   items=$(jq 'map(del(.children))' <<< "$items")


### PR DESCRIPTION
- Remove debugging code
- Add editors back in -- updated bibSplit.pl functions
- Remove author and editor code from bib-fns.jq (in Perl now)
- Remove author and editor calls.  Done in Perl script
- Update taxonomy filter to include term pages (authors, etc)