### PR TITLE
Update grid class fot td-sidebar-toc to use all the available space.

### DIFF
--- a/layouts/bibliography/baseof.html
+++ b/layouts/bibliography/baseof.html
@@ -13,7 +13,7 @@
     <div class="container-fluid td-outer">
       <div class="td-main" {{- .Section | safeHTMLAttr }}>
         <div class="row flex-xl-nowrap">
-          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+          <aside class="d-none d-xl-block col-xl-4 td-sidebar-toc d-print-none">
             {{ partial "page-meta-links.html" . }}
             {{ partial "toc.html" . }}
             {{ partial "taxonomy_terms_clouds.html" . }}


### PR DESCRIPTION
The screen is divided into 12 columns, the existing layout was only using 10.  Updated toc (where the taxonomy lives) to use the remaining 2 columns.