### PR TITLE
Fix logo in annual reports.

### DIFF
--- a/content/en/project/status/2023MedleyAnnualReport.md
+++ b/content/en/project/status/2023MedleyAnnualReport.md
@@ -7,7 +7,7 @@ aliases:
  - /project/news/2023medleyannualreport/
 ---
 
-<img src="/Resources/logo_red_no_border_568x385.png" width="284" height="194"></img>
+{{< figure src="/Resources/logo_red_no_border_568x385.png" width="284" height="194" >}}
 
 ### **Overview**
 

--- a/content/en/project/status/2024MedleyAnnualReport.md
+++ b/content/en/project/status/2024MedleyAnnualReport.md
@@ -7,7 +7,8 @@ aliases:
  - /project/news/2023medleyannualreport/
 ---
 
-<img src="/Resources/logo_red_no_border_568x385.png" width="284" height="194"></img>
+{{< figure src="/Resources/logo_red_no_border_568x385.png" width="284" height="194" >}}
+
 
 ## **Overview**
 

--- a/content/en/project/status/2025MedleyAnnualReport.md
+++ b/content/en/project/status/2025MedleyAnnualReport.md
@@ -7,7 +7,7 @@ aliases:
  - /project/news/2025medleyannualreport/
 ---
 
-<img src="/Resources/logo_red_no_border_568x385.png" width="284" height="194"></img>
+{{< figure src="/Resources/logo_red_no_border_568x385.png" width="284" height="194" >}}
 
 ## **Overview**
 


### PR DESCRIPTION
Move logo from html <img/> to Hugo figure shortcode.  This fixes the issues with the base url.