### PR TITLE
Update params to remove feedback page and Git commit information

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -41,17 +41,17 @@ copyright:
   from_year: 2024
   license: MIT
 
-# github information
+# github information - disabled, only needed if feedback is enabled.
 #  github_repo:  url to repo of web site
 #  github_branch:  main branch of repo
 #  github_subdir:  unused by Interlisp.org
 #  github_project_repo: added by Interlisp.org points to repo used
 #                       for issue reporting
 #  
-github_repo: https://github.com/interlisp/Interlisp.github.io
-github_branch: main
-github_subdir: 
-github_project_repo: https://github.com/interlisp/medley
+#github_repo: https://github.com/interlisp/Interlisp.github.io
+#github_branch: main
+#github_subdir: 
+#github_project_repo: https://github.com/interlisp/medley
 
 # Google custom search engine configuration
 #  gcs_engine_id:  search engine 
@@ -136,30 +136,11 @@ taxonomy:
 
 # User Interface Configuration options
 #
-# feedback:
-#   Adds a H2 section titled "Feedback" to the bottom of each doc. The responses 
-#   are sent to Google Analytics as events.  This feature depends 
-#   on [services.googleAnalytics] and will be disabled if 
-#   "services.googleAnalytics.id" is not set.
-#
-#   If you want this feature, but occasionally need to remove the 
-#   "Feedback" section from a single page,
-#   add "hide_feedback: true" to the page's front matter.
-#    enable:  boolean Turn feedback
-#    yes: text to display with yes is selected
-#    no: text to display when no is selected
-
 ui:
+  # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses 
+  # are sent to Google Analytics as events.  
   feedback:
-    enable: true
-    yes: >-
-      Glad to hear it! Please <a 
-      href="https://github.com/Interlisp/medley/issues/new?template=documentation.md&projects=Interlisp/medley/5">
-      tell us how we can improve</a>.
-    no: >-
-      Sorry to hear that. Please <a 
-      href="https://github.com/Interlisp/medley/issues/new?template=documentation.md&projects=Interlisp/medley/5">
-      tell us how we can improve</a>.
+    enable: false
 
   # Adds a reading time to the top of each doc.
   # If you want this feature, but occasionally need to remove the Reading time from a single page, 


### PR DESCRIPTION
Removed the feedback buttons and the footer stating when the page was last updated and the associated commit.