### PR TITLE
CLeanup changes suggested by Copilot

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -40,6 +40,10 @@ permissions:
     pages: write
     id-token: write
 
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
     run:
         shell: bash
@@ -60,7 +64,7 @@ jobs:
   check:
     outputs:
       zoteroVersion: ${{ steps.zoteroVersion.outputs.version }}
-      cacheHit: ${{ steps.cache-zotero-bib.outputs.cache-hit }}
+      cacheHit: ${{ steps.cache-zotero.outputs.cache-hit }}
 
     runs-on: ubuntu-latest
     steps:
@@ -76,7 +80,7 @@ jobs:
 
       - name: Cache Zotero Bibliography
         id: cache-zotero
-        uses: actions/cache/restore@v5.0.3
+        uses: actions/cache/restore@v5
         with:
           lookup-only: true
           path: |
@@ -132,7 +136,7 @@ jobs:
 
       - name: Cache Zotero Bibliography
         id: cache-bib
-        uses: actions/cache@v5.0.3
+        uses: actions/cache@v5
         with:
           path: |
             static/data/bibliography.json
@@ -164,15 +168,17 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-      
-      - run: npm install -g autoprefixer --save-dev  
-      - run: npm install -g postcss-cli --save-dev
-      - run: npm install --verbose
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm install -g autoprefixer postcss-cli
+          npm install
 
       - name: Build
         env:
           HUGO_CACHEDIR: ${{ runner.temp }}/hugo_cache
-          TZ: America/New York
+          TZ: America/New_York
         run: hugo --cleanDestinationDir -e $HUGO_ENVIRONMENT
         
       - name: Upload artifact


### PR DESCRIPTION
Fixes a couple minor issues:
 - TZ specified incorrectly
 - Add concurrency group to prevent parallel deployments
 - Cleaned up npm install and adding caching
 - Fix incorrect ID reference
 - Switch from v5.0.3 to v5 for cache actions to automatically get security updates.