### PR TITLE
GHA Updates - revise cache key

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -67,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - uses: actions/checkout@v6
+
       - name: Get Zotero Version Information
         id: zoteroVersion
         run: |
@@ -88,7 +90,7 @@ jobs:
           lookup-only: true
           path: |
             content/en/history/bibliography
-          key: bib-${{ steps.zoteroVersion.outputs.version }}
+          key: bib-${{ steps.zoteroVersion.outputs.version }}-${{ hashFiles('content/en/history/bibliography/_index.md', 'content/en/history/bibliography/intake/**') }}
 
   # ----------------------------------------------------------------------------
   # Validate that README.md references the correct Hugo version.
@@ -145,7 +147,7 @@ jobs:
             static/data/bibliography.json
             static/data/bibItems
             content/en/history/bibliography
-          key: bib-${{ needs.check.outputs.zoteroVersion }}
+          key: bib-${{ needs.check.outputs.zoteroVersion }}-${{ hashFiles('content/en/history/bibliography/_index.md', 'content/en/history/bibliography/intake/**') }}
 
       - name: Install Bibliography
         if: steps.cache-bib.outputs.cache-hit != 'true'

--- a/content/en/history/bibliography/_index.md
+++ b/content/en/history/bibliography/_index.md
@@ -10,5 +10,5 @@ aliases:
  - /bibliography/
 
 ---
-Information on submitting new entries can be forund at [Interlisp Bibliography Submission](intake)  
+Information on submitting new entries can be found at [Interlisp Bibliography Submission](intake)  
 We generate this from our [Zotero collection library](https://www.zotero.org/groups/2914042/interlisp/library).


### PR DESCRIPTION
Currently we only use the Zotero version as a cache key and we cache both the generated Zotero bibliography entries along with the human generated files.  The change to _index.md and future changes to the intake md files would never be recognized.  Changes would only be propogated when Zotero was updated.

The updated key looks for both changes to Zotero and the bibliography directory.